### PR TITLE
플레이어 포커스 및 버그 해결

### DIFF
--- a/EscapeDragonPalace/Rabbit.c
+++ b/EscapeDragonPalace/Rabbit.c
@@ -84,9 +84,6 @@ char Rabbit[14][RabbitY][RabbitX] =
 };
 
 
-bool g_KeyW = false;
-bool g_KeyA = false;
-bool g_KeyD = false;
 
 bool halfHealth = false; // 체력 반칸
 
@@ -109,8 +106,38 @@ bool isNearItem = false;
 
 bool stageClear = false; // 스테이지 클리어 여부
 
+bool g_KeyW = false;
+bool g_KeyA = false;
+bool g_KeyD = false;
+bool g_KeyS = false;
+
+bool IsMapEnd = false;
 
 // --------------------------------------------------
+
+bool MapEnd(bool src)
+{
+    IsMapEnd = src;
+}
+bool GetKeyW()
+{
+    return g_KeyW;
+}
+
+bool GetKeyA()
+{
+    return g_KeyA;
+}
+
+bool GetKeyD()
+{
+    return g_KeyD;
+}
+
+bool GetKeyS()
+{
+    return g_KeyS;
+}
 
 bool IsNearItem()
 {
@@ -292,6 +319,7 @@ void GetInput() // GetAsyncKeyState로 다중 키 입력 감지
     g_KeyW = (GetAsyncKeyState('W') & 0x8000);
     g_KeyA = (GetAsyncKeyState('A') & 0x8000);
     g_KeyD = (GetAsyncKeyState('D') & 0x8000);
+    g_KeyS = (GetAsyncKeyState('S') & 0x8000);
 
     // 마우스 왼쪽 버튼 클릭 여부
     g_MouseClick = (GetAsyncKeyState(VK_LBUTTON) & 0x8000);
@@ -388,11 +416,27 @@ void moveFN()
 
     if (g_KeyA)
     {
+        if (IsMapEnd)
+        {
+            move = player.IsJumping ? player.Speed * 1.2f : player.Speed;
+        }
+        else if (player.Pos.x < 25)
+        {
+            move = 0;
+        }
         player.Pos.x -= move;
         player.Direction = 1;
     }
     if (g_KeyD)
     {
+        if (IsMapEnd)
+        {
+            move = player.IsJumping ? player.Speed * 1.2f : player.Speed;
+        }
+        else if (player.Pos.x > 25)
+        {
+            move = 0;
+        }
         player.Pos.x += move;
         player.Direction = 0;
     }

--- a/EscapeDragonPalace/Rabbit.h
+++ b/EscapeDragonPalace/Rabbit.h
@@ -6,6 +6,11 @@
 
 // --------------------------------------------------
 
+bool MapEnd();
+bool GetKeyW();
+bool GetKeyA();
+bool GetKeyD();
+bool GetKeyS();
 bool IsNearItem();
 void SetIsNearItem(bool src);
 bool StageClear();
@@ -81,4 +86,7 @@ void CheckItemPickup();
 void UpdateSpeedBuffs();
 
 SpeedBuff speedBuffs[MAX_BUFFS];
+
+
+
 

--- a/EscapeDragonPalace/map.c
+++ b/EscapeDragonPalace/map.c
@@ -1,5 +1,6 @@
 #include "init.h"
 #include "map.h"
+#include "Rabbit.h"
 
 int g_Plus_Y = 24; // °¨¿Á, ¿ë±Ã ¸Ê ½ÃÀÛ À§Ä¡
 int g_Plus_X = 0; // ¹Ù´Ù 1, 2 ¸Ê ½ÃÀÛ À§Ä¡
@@ -160,18 +161,26 @@ void UpdateMapPos()
 			g_Plus_Y = 24;
 		break;
 	case E_Sea1: case E_Sea2:
-		if (g_Key == 'a' || g_Key == 'A')
+		if (GetKeyA() && player.Pos.x <= 24 || GetAsyncKeyState('A') & 0x8000)
 		{
-			g_Plus_X -= 2;
+			MapEnd(false);
+			g_Plus_X -= player.Speed;
 		}
-		else if (g_Key == 'd' || g_Key == 'D')
+		else if (GetKeyD() && player.Pos.x >= 26 || GetAsyncKeyState('D') & 0x8000)
 		{
-			g_Plus_X += 2;
+			MapEnd(false);
+			g_Plus_X += player.Speed;
 		}
 		if (g_Plus_X < 0)
+		{
 			g_Plus_X = 0;
+			MapEnd(true);
+		}
 		else if (g_Plus_X > 222)
+		{
 			g_Plus_X = 222;
+			MapEnd(true);
+		}
 		break;
 	}
 


### PR DESCRIPTION
- 플레이어 이동 시 x좌표 포커스 맞춤 (바다1,2 맵만 적용)
- 이동 중 점프 키 입력 시 이동 멈춤 버그